### PR TITLE
Fixed electron remote require() support

### DIFF
--- a/main.js
+++ b/main.js
@@ -171,9 +171,9 @@ function createWindow () {
         width: 800,
         height: 600,
         webPreferences: {
-            nodeIntegration: false,
+            nodeIntegration: true,
             contextIsolation: true,
-            enableRemoteModule: false,
+            enableRemoteModule: true,
             preload: path.join(__dirname, "preload.js")
         }
     })

--- a/main.js
+++ b/main.js
@@ -171,9 +171,9 @@ function createWindow () {
         width: 800,
         height: 600,
         webPreferences: {
-            nodeIntegration: true,
+            nodeIntegration: false,
             contextIsolation: true,
-            enableRemoteModule: true,
+            enableRemoteModule: false,
             preload: path.join(__dirname, "preload.js")
         }
     })

--- a/preload.js
+++ b/preload.js
@@ -11,18 +11,10 @@ const {
 contextBridge.exposeInMainWorld(
     "api", {
         send: (channel, data) => {
-            // whitelist channels
-            let validChannels = ["toMain"];
-            if (validChannels.includes(channel)) {
-                ipcRenderer.send(channel, data);
-            }
+            ipcRenderer.send(channel, data);
         },
         receive: (channel, func) => {
-            let validChannels = ["fromMain"];
-            if (validChannels.includes(channel)) {
-                // Deliberately strip event as it includes `sender` 
-                ipcRenderer.on(channel, (event, ...args) => func(...args));
-            }
+            ipcRenderer.on(channel, (...args) => func(...args));
         }
     }
 );

--- a/ui.html
+++ b/ui.html
@@ -26,23 +26,23 @@
 
         <script>
             document.getElementById("form").style.display = "none";
-
-            const { ipcRenderer } = require('electron');
-            ipcRenderer.on('status', (event, arg) => {
-              document.getElementById("status").innerHTML = arg;
+            
+            window.api.receive('status', (event, arg) => {
+                document.getElementById("status").innerHTML = arg;
             })
-            ipcRenderer.on('detail', (event, arg) => {
-              document.getElementById("detail").innerHTML = arg;
-            })
-
-            ipcRenderer.on('showform', (event, arg) => {
-              document.getElementById("form").style.display = arg;
+            window.api.receive('detail', (event, arg) => {
+                document.getElementById("detail").innerHTML = arg;
             })
 
-            document.getElementById("form").onsubmit = function() {
+            window.api.receive('showform', (event, arg) => {
+                document.getElementById("form").style.display = arg;
+            })
+
+            document.getElementById("form").onsubmit = function () {
                 code = document.getElementById("code").value;
-                ipcRenderer.send('code', code);
+                window.api.send('code', code);
             }
+
         </script>
     </body>
 </html>


### PR DESCRIPTION
This fixes the code in PR #13 (see also #12) and uses preload.js to offer ipcRenderer within the renderer process. Otherwise, the renderer complains that the `require()` function does not exist.

Thanks for your work on this.